### PR TITLE
tokio 0.1 futures 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,17 @@ readme = "README.md"
 keywords = ["zmq", "zeromq", "futures", "tokio"]
 
 [dependencies]
-zmq = "0.8"
-futures = "0.1"
-tokio-core = "0.1"
-tokio-file-unix = "0.4"
+futures = "0.2.0-alpha"
 log = "0.4"
-tokio-timer = "0.1"
+mio = "0.6"
+tokio-file-unix = "0.4"
+tokio-timer = { path = "../tokio-timer", version = "0.1.2" }
 tokio-zmq-derive = { path = "tokio-zmq-derive", version = "0.1.2" }
+zmq = "0.8"
+
+[dependencies.tokio]
+git = "https://github.com/tokio-rs/tokio.git"
+features = [ "unstable-futures" ]
 
 [dev-dependencies]
 env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,9 @@ zmq = "0.8"
 git = "https://github.com/tokio-rs/tokio.git"
 features = [ "unstable-futures" ]
 
+[dev-dependencies.tokio-executor]
+git = "https://github.com/tokio-rs/tokio.git"
+features = [ "unstable-futures" ]
+
 [dev-dependencies]
 env_logger = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-zmq"
 description = "Provides Futures abstractions for ZeroMQ on the Tokio event-loop"
-version = "0.3.0"
+version = "0.4.0"
 license = "GPL-3.0"
 authors = ["Riley Trautman <asonix.dev@gmail.com>"]
 repository = "https://github.com/asonix/tokio-zmq"
@@ -14,7 +14,7 @@ log = "0.4"
 mio = "0.6"
 tokio-file-unix = "0.4"
 tokio-timer = { path = "../tokio-timer", version = "0.1.2" }
-tokio-zmq-derive = { path = "tokio-zmq-derive", version = "0.1.2" }
+tokio-zmq-derive = { path = "tokio-zmq-derive", version = "0.4.0" }
 zmq = "0.8"
 
 [dependencies.tokio]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.2.0-alpha"
 log = "0.4"
 mio = "0.6"
 tokio-file-unix = "0.4"
-tokio-timer = { path = "../tokio-timer", version = "0.1.2" }
+tokio-timer-futures2 = "0.2"
 tokio-zmq-derive = { path = "tokio-zmq-derive", version = "0.4.0" }
 zmq = "0.8"
 

--- a/examples/dealer_router.rs
+++ b/examples/dealer_router.rs
@@ -63,8 +63,8 @@ fn client() {
 
     println!("Sending 'Hewwo?' for 0");
     let runner = req.send(zmq::Message::from_slice(b"Hewwo?").unwrap().into())
-        .and_then(|(sock, file)| {
-            let (sink, stream) = Socket::from_sock_and_file(sock, file).sink_stream().split();
+        .and_then(|req| {
+            let (sink, stream) = req.sink_stream().split();
 
             stream
                 .zip(iter_ok(1..CLIENT_REQUESTS))

--- a/examples/load_balancing_broker.rs
+++ b/examples/load_balancing_broker.rs
@@ -263,14 +263,11 @@ fn broker_task() {
                 .map(|_| multipart)
                 .map_err(|_| Error::WorkerSend)
         })
-        .and_then(|mut multipart| {
+        .filter_map(|mut multipart| {
             let empty = multipart.pop_front().ok_or(Error::NotEnoughMessages)?;
             assert!(empty.is_empty());
             let client_id = multipart.pop_front().ok_or(Error::NotEnoughMessages)?;
 
-            Ok((multipart, client_id))
-        })
-        .filter_map(|(multipart, client_id)| {
             if &*client_id == b"READY" {
                 Ok(None)
             } else {

--- a/examples/load_balancing_broker.rs
+++ b/examples/load_balancing_broker.rs
@@ -22,19 +22,18 @@
 extern crate env_logger;
 extern crate futures;
 extern crate log;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_zmq;
 extern crate zmq;
 
 use std::env;
 use std::convert::{TryFrom, TryInto};
-use std::rc::Rc;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use futures::{Future, Sink, Stream};
-use futures::sync::mpsc;
-use tokio_core::reactor::Core;
+use futures::{FutureExt, SinkExt, StreamExt};
+use futures::channel::mpsc;
 use tokio_zmq::prelude::*;
 use tokio_zmq::{Pub, Req, Router, Sub};
 use tokio_zmq::{Multipart, Socket};
@@ -138,73 +137,80 @@ impl ControlHandler for Stop {
 /* ----------------------------------client---------------------------------- */
 
 fn client_task(client_num: usize) -> usize {
-    let mut core = Core::new().unwrap();
-    let context = Rc::new(zmq::Context::new());
+    let context = Arc::new(zmq::Context::new());
 
-    let client: Req = Socket::builder(context, &core.handle())
+    let client: Req = Socket::builder(context)
         .identity(format!("c{}", client_num).as_bytes())
         .connect("tcp://localhost:5672")
         .try_into()
         .unwrap();
 
     let msg = zmq::Message::from_slice(b"HELLO").unwrap();
-    let resp = client.recv();
     let fut = client
         .send(msg.into())
-        .and_then(|_| resp)
-        .and_then(|multipart| {
+        .and_then(|(sock, file)| Socket::from_sock_and_file(sock, file).recv())
+        .and_then(move |(multipart, _, _)| {
             if let Some(msg) = multipart.get(0) {
                 println!("Client {}: {:?}", client_num, msg.as_str());
             }
             Ok(())
         });
 
-    core.run(fut).unwrap();
+    tokio::runtime::run2(fut.map(|_| ()).or_else(|e| {
+        println!("Error in client: {:?}", e);
+        Ok(())
+    }));
     client_num
 }
 
 /* ----------------------------------worker---------------------------------- */
 
 fn worker_task(worker_num: usize) -> usize {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let context = Rc::new(zmq::Context::new());
+    let context = Arc::new(zmq::Context::new());
 
-    let control: Sub = Socket::builder(Rc::clone(&context), &handle)
+    let control: Sub = Socket::builder(Arc::clone(&context))
         .connect("tcp://localhost:5674")
         .filter(b"")
         .try_into()
         .unwrap();
-    let worker: Req = Socket::builder(context, &handle)
+    let worker: Req = Socket::builder(context)
         .identity(format!("w{}", worker_num).as_bytes())
         .connect("tcp://localhost:5673")
         .try_into()
         .unwrap();
 
     let msg = zmq::Message::from_slice(b"READY").unwrap();
-    let fut = worker.send(msg.into()).map_err(Error::from);
 
-    let inner_fut = worker
-        .stream()
-        .controlled(control, Stop)
+    let fut = worker
+        .send(msg.into())
         .map_err(Error::from)
-        .and_then(|multipart| {
-            let mut envelope: Envelope = multipart.try_into()?;
+        .and_then(move |(sock, file)| {
+            let (sink, stream) = Socket::from_sock_and_file(sock, file).sink_stream().split();
 
-            println!(
-                "Worker: {:?} from {:?}",
-                envelope.request().as_str(),
-                envelope.addr().as_str()
-            );
+            stream
+                .controlled(control.stream(), Stop)
+                .map_err(Error::from)
+                .and_then(|multipart| {
+                    let mut envelope: Envelope = multipart.try_into()?;
 
-            let msg = zmq::Message::from_slice(b"OK")?;
-            envelope.set_request(msg);
+                    println!(
+                        "Worker: {:?} from {:?}",
+                        envelope.request().as_str(),
+                        envelope.addr().as_str()
+                    );
 
-            Ok(envelope.into())
-        })
-        .forward(worker.sink::<Error>());
+                    let msg = zmq::Message::from_slice(b"OK")?;
+                    envelope.set_request(msg);
 
-    core.run(fut.and_then(|_| inner_fut)).unwrap();
+                    Ok(envelope.into())
+                })
+                .forward(sink)
+        });
+
+    tokio::runtime::run2(fut.map(|_| ()).or_else(|e| {
+        println!("Error in worker: {:?}", e);
+        Ok(())
+    }));
     println!("Worker {} is done", worker_num);
     worker_num
 }
@@ -212,38 +218,38 @@ fn worker_task(worker_num: usize) -> usize {
 /* ----------------------------------broker---------------------------------- */
 
 fn broker_task() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let context = Rc::new(zmq::Context::new());
+    let context = Arc::new(zmq::Context::new());
 
-    let frontend: Router = Socket::builder(Rc::clone(&context), &handle)
+    let frontend: Router = Socket::builder(Arc::clone(&context))
         .bind("tcp://*:5672")
         .try_into()
         .unwrap();
 
-    let control: Sub = Socket::builder(Rc::clone(&context), &handle)
+    let control: Sub = Socket::builder(Arc::clone(&context))
         .connect("tcp://localhost:5674")
         .filter(b"")
         .try_into()
         .unwrap();
 
-    let backend: Router = Socket::builder(context, &handle)
+    let backend: Router = Socket::builder(context)
         .bind("tcp://*:5673")
         .try_into()
         .unwrap();
 
     let (worker_send, worker_recv) = mpsc::channel::<zmq::Message>(10);
 
-    let back2front = backend
-        .stream()
-        .controlled(control, Stop)
+    let (frontend_sink, frontend_stream) = frontend.sink_stream().split();
+    let (backend_sink, backend_stream) = backend.sink_stream().split();
+
+    let back2front = backend_stream
+        .controlled(control.stream(), Stop)
         .map_err(Error::from)
         .and_then(|mut multipart| {
             let worker_id = multipart.pop_front().ok_or(Error::NotEnoughMessages)?;
 
             Ok((multipart, worker_id))
         })
-        .and_then(|(multipart, worker_id)| {
+        .and_then(move |(multipart, worker_id)| {
             worker_send
                 .clone()
                 .send(worker_id)
@@ -259,9 +265,9 @@ fn broker_task() {
         })
         .filter_map(|(multipart, client_id)| {
             if &*client_id == b"READY" {
-                None
+                Ok(None)
             } else {
-                Some((multipart, client_id))
+                Ok(Some((multipart, client_id)))
             }
         })
         .and_then(|(mut multipart, client_id)| {
@@ -277,10 +283,9 @@ fn broker_task() {
 
             Ok(response)
         })
-        .forward(frontend.sink::<Error>());
+        .forward(frontend_sink);
 
-    let front2back = frontend
-        .stream()
+    let front2back = frontend_stream
         .map_err(Error::from)
         .zip(worker_recv.map_err(|_| Error::WorkerRecv))
         .and_then(|(mut multipart, worker_id)| {
@@ -299,13 +304,12 @@ fn broker_task() {
 
             Ok(response)
         })
-        .forward(backend.sink::<Error>())
-        .map(|_| ())
-        .map_err(|e| println!("Error: {:?}", e));
+        .forward(backend_sink);
 
-    handle.spawn(front2back);
-
-    core.run(back2front).unwrap();
+    tokio::runtime::run2(front2back.join(back2front).map(|_| ()).or_else(|e| {
+        println!("Error in broker: {:?}", e);
+        Ok(())
+    }));
     println!("Broker is done");
 }
 
@@ -345,9 +349,8 @@ fn main() {
     match use_broker {
         UseBroker::No | UseBroker::All => {
             // Set up control socket
-            let mut core = Core::new().unwrap();
-            let context = Rc::new(zmq::Context::new());
-            let control: Pub = Socket::builder(context, &core.handle())
+            let context = Arc::new(zmq::Context::new());
+            let control: Pub = Socket::builder(context)
                 .bind("tcp://*:5674")
                 .try_into()
                 .unwrap();
@@ -358,7 +361,7 @@ fn main() {
 
             let clients = (0..NUM_CLIENTS)
                 .map(|client_num| {
-                    if client_num % 20 == 0 {
+                    if client_num % 5 == 0 {
                         println!("Sleeping to avoid too many open files");
                         thread::sleep(Duration::from_millis(20));
                     }
@@ -372,8 +375,15 @@ fn main() {
             }
 
             // Signal end when all clients have joined
-            core.run(control.send(zmq::Message::new().unwrap().into()))
-                .unwrap();
+            tokio::runtime::run2(
+                control
+                    .send(zmq::Message::new().unwrap().into())
+                    .map(|_| ())
+                    .or_else(|e| {
+                        println!("Error in main loop {:?}", e);
+                        Ok(())
+                    }),
+            );
 
             for worker in workers {
                 let worker_num = worker.join().unwrap();

--- a/examples/load_balancing_broker.rs
+++ b/examples/load_balancing_broker.rs
@@ -39,7 +39,8 @@ use tokio_zmq::{Pub, Req, Router, Sub};
 use tokio_zmq::{Multipart, Socket};
 
 const NUM_CLIENTS: usize = 1000;
-const NUM_WORKERS: usize = 3;
+const NUM_WORKERS: usize = 5;
+const BATCH_SIZE: usize = 10;
 
 /* ----------------------------------Error----------------------------------- */
 
@@ -368,7 +369,7 @@ fn main() {
 
             let clients = (0..NUM_CLIENTS)
                 .map(|client_num| {
-                    if client_num % 5 == 0 {
+                    if client_num % BATCH_SIZE == 0 {
                         println!("Sleeping to avoid too many open files");
                         thread::sleep(Duration::from_millis(20));
                     }

--- a/examples/load_balancing_broker.rs
+++ b/examples/load_balancing_broker.rs
@@ -149,8 +149,8 @@ fn client_task(client_num: usize) -> usize {
     let msg = zmq::Message::from_slice(b"HELLO").unwrap();
     let fut = client
         .send(msg.into())
-        .and_then(|(sock, file)| Socket::from_sock_and_file(sock, file).recv())
-        .and_then(move |(multipart, _, _)| {
+        .and_then(|client| client.recv())
+        .and_then(move |(multipart, _)| {
             if let Some(msg) = multipart.get(0) {
                 println!("Client {}: {:?}", client_num, msg.as_str());
             }
@@ -185,8 +185,8 @@ fn worker_task(worker_num: usize) -> usize {
     let fut = worker
         .send(msg.into())
         .map_err(Error::from)
-        .and_then(move |(sock, file)| {
-            let (sink, stream) = Socket::from_sock_and_file(sock, file).sink_stream().split();
+        .and_then(move |worker| {
+            let (sink, stream) = worker.sink_stream().split();
 
             stream
                 .controlled(control.stream(), Stop("worker", worker_num))

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -28,12 +28,10 @@ extern crate zmq;
 use std::sync::Arc;
 use std::convert::TryInto;
 
-use futures::{FutureExt, IntoFuture, StreamExt};
-use futures::future::Either;
+use futures::{FutureExt, StreamExt};
 use tokio_zmq::prelude::*;
 use tokio_zmq::{Pub, Pull, Sub};
 use tokio_zmq::{Multipart, Socket};
-use tokio_zmq::Error;
 
 pub struct Stop;
 

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -66,11 +66,7 @@ fn main() {
                 .filter_map(|msg| {
                     let stop = if let Some(s_msg) = msg.as_str() {
                         println!("msg: '{}'", s_msg);
-                        if s_msg == "STOP" {
-                            true
-                        } else {
-                            false
-                        }
+                        s_msg == "STOP"
                     } else {
                         false
                     };

--- a/examples/pull.rs
+++ b/examples/pull.rs
@@ -59,7 +59,7 @@ fn main() {
         .unwrap();
 
     let process = conn.stream()
-        .controlled(cmd, Stop)
+        .controlled(cmd.stream(), Stop)
         .filter_map(|multipart| {
             Ok(multipart
                 .into_iter()

--- a/examples/pull_push.rs
+++ b/examples/pull_push.rs
@@ -59,7 +59,7 @@ fn main() {
 
     let runner = stream
         .stream()
-        .controlled(cmd, Stop)
+        .controlled(cmd.stream(), Stop)
         .map(|multipart| {
             for msg in &multipart {
                 if let Some(msg) = msg.as_str() {

--- a/examples/pull_push.rs
+++ b/examples/pull_push.rs
@@ -20,18 +20,17 @@
 #![feature(try_from)]
 
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_zmq;
 extern crate zmq;
 
-use std::rc::Rc;
+use std::sync::Arc;
 use std::convert::TryInto;
 
-use futures::Stream;
-use tokio_core::reactor::Core;
+use futures::{FutureExt, StreamExt};
 use tokio_zmq::prelude::*;
 use tokio_zmq::{Pull, Push, Sub};
-use tokio_zmq::{Error as ZmqFutError, Multipart, Socket};
+use tokio_zmq::{Multipart, Socket};
 
 pub struct Stop;
 
@@ -43,19 +42,17 @@ impl ControlHandler for Stop {
 }
 
 fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let ctx = Rc::new(zmq::Context::new());
-    let cmd: Sub = Socket::builder(Rc::clone(&ctx), &handle)
+    let ctx = Arc::new(zmq::Context::new());
+    let cmd: Sub = Socket::builder(Arc::clone(&ctx))
         .connect("tcp://localhost:5559")
         .filter(b"")
         .try_into()
         .unwrap();
-    let stream: Pull = Socket::builder(Rc::clone(&ctx), &handle)
+    let stream: Pull = Socket::builder(Arc::clone(&ctx))
         .connect("tcp://localhost:5557")
         .try_into()
         .unwrap();
-    let sink: Push = Socket::builder(ctx, &handle)
+    let sink: Push = Socket::builder(ctx)
         .connect("tcp://localhost:5558")
         .try_into()
         .unwrap();
@@ -71,7 +68,10 @@ fn main() {
             }
             multipart
         })
-        .forward(sink.sink::<ZmqFutError>());
+        .forward(sink.sink());
 
-    core.run(runner).unwrap();
+    tokio::runtime::run2(runner.map(|_| ()).or_else(|e| {
+        println!("Error!: {:?}", e);
+        Ok(())
+    }));
 }

--- a/examples/push.rs
+++ b/examples/push.rs
@@ -21,7 +21,7 @@
 
 extern crate futures;
 extern crate tokio;
-extern crate tokio_timer;
+extern crate tokio_timer_futures2 as tokio_timer;
 extern crate tokio_zmq;
 extern crate zmq;
 

--- a/examples/push.rs
+++ b/examples/push.rs
@@ -20,18 +20,19 @@
 #![feature(try_from)]
 
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
+extern crate tokio_timer;
 extern crate tokio_zmq;
 extern crate zmq;
 
 use std::io;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 use std::convert::TryInto;
 
-use futures::{Future, Stream};
+use futures::{FutureExt, StreamExt};
 use futures::stream::iter_ok;
-use tokio_core::reactor::{Core, Interval};
+use tokio_timer::{Timer, TimerError};
 use tokio_zmq::prelude::*;
 use tokio_zmq::{Error as ZmqFutError, Push, Socket};
 
@@ -40,6 +41,7 @@ enum Error {
     ZmqFut(ZmqFutError),
     Zmq(zmq::Error),
     Io(io::Error),
+    Timer(TimerError),
 }
 
 impl From<ZmqFutError> for Error {
@@ -60,15 +62,23 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<TimerError> for Error {
+    fn from(e: TimerError) -> Self {
+        Error::Timer(e)
+    }
+}
+
 fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let ctx = Rc::new(zmq::Context::new());
-    let workers: Push = Socket::builder(Rc::clone(&ctx), &handle)
+    let ctx = Arc::new(zmq::Context::new());
+    let workers: Push = Socket::builder(Arc::clone(&ctx))
         .bind("tcp://*:5557")
         .try_into()
         .unwrap();
-    let sink: Push = Socket::builder(ctx, &handle)
+    let sink: Push = Socket::builder(Arc::clone(&ctx))
+        .connect("tcp://localhost:5558")
+        .try_into()
+        .unwrap();
+    let sink2: Push = Socket::builder(ctx)
         .connect("tcp://localhost:5558")
         .try_into()
         .unwrap();
@@ -76,7 +86,7 @@ fn main() {
     let start_msg = zmq::Message::from_slice(b"START").unwrap().into();
     let stop_msg = zmq::Message::from_slice(b"STOP").unwrap().into();
 
-    let interval = Interval::new(Duration::from_millis(200), &core.handle()).unwrap();
+    let interval = Timer::default().interval(Duration::from_millis(200));
 
     let process = sink.send(start_msg).map_err(Error::from).and_then(|_| {
         iter_ok(0..10)
@@ -91,9 +101,12 @@ fn main() {
 
                 Ok(msg.into())
             })
-            .forward(workers.sink::<Error>())
-            .and_then(move |_| sink.send(stop_msg).map_err(Error::from))
+            .forward(workers.sink())
+            .and_then(move |_| sink2.send(stop_msg).map_err(Error::from))
     });
 
-    core.run(process).unwrap();
+    tokio::runtime::run2(process.map(|_| ()).or_else(|e| {
+        println!("Error: {:?}", e);
+        Ok(())
+    }));
 }

--- a/examples/sync_pubsub.rs
+++ b/examples/sync_pubsub.rs
@@ -118,11 +118,11 @@ fn subscriber_thread() {
 
     let runner = syncclient
         .send(msg.into())
-        .and_then(|(sock, file)| Socket::from_sock_and_file(sock, file).recv())
+        .and_then(|syncclient| syncclient.recv())
         .and_then(move |_| {
             subscriber
                 .stream()
-                .with_end(Stop)
+                .with_end_handler(Stop)
                 .fold(0, |counter, _| Ok(counter + 1) as Result<usize, Error>)
                 .and_then(|total| {
                     println!("Received {} updates", total);

--- a/examples/sync_pubsub.rs
+++ b/examples/sync_pubsub.rs
@@ -22,18 +22,17 @@
 extern crate env_logger;
 extern crate futures;
 extern crate log;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_zmq;
 extern crate zmq;
 
-use std::rc::Rc;
 use std::convert::TryInto;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
 use futures::stream::iter_ok;
-use futures::{Future, Stream};
-use tokio_core::reactor::Core;
+use futures::{FutureExt, SinkExt, StreamExt};
 use tokio_zmq::prelude::*;
 use tokio_zmq::{Pub, Rep, Req, Sub};
 use tokio_zmq::{Error, Multipart, Socket};
@@ -62,66 +61,65 @@ impl EndHandler for Stop {
 }
 
 fn publisher_thread() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let ctx = Rc::new(zmq::Context::new());
+    let ctx = Arc::new(zmq::Context::new());
 
-    let publisher: Pub = Socket::builder(Rc::clone(&ctx), &handle)
+    let publisher: Pub = Socket::builder(Arc::clone(&ctx))
         .bind("tcp://*:5561")
         .try_into()
         .unwrap();
 
-    let syncservice: Rep = Socket::builder(ctx, &handle)
+    let syncservice: Rep = Socket::builder(ctx)
         .bind("tcp://*:5562")
         .try_into()
         .unwrap();
 
     println!("Waiting for subscribers");
 
+    let (sync_sink, sync_stream) = syncservice.sink_stream().split();
+
     let runner = iter_ok(0..SUBSCRIBERS)
-        .zip(syncservice.stream())
+        .zip(sync_stream)
         .map(|(_, _)| zmq::Message::from_slice(b"").unwrap().into())
-        .forward(syncservice.sink::<Error>())
-        .and_then(|_| {
+        .forward(sync_sink)
+        .and_then(move |_| {
             println!("Broadcasting message");
 
             iter_ok(0..MESSAGES)
                 .map(|_| zmq::Message::from_slice(b"Rhubarb").unwrap().into())
-                .forward(publisher.sink::<Error>())
+                .forward(publisher.sink())
         })
-        .and_then(|_| {
+        .and_then(|(_stream, sink)| {
             let msg = zmq::Message::from_slice(b"END").unwrap();
 
-            publisher.send(msg.into())
+            sink.send(msg.into())
         });
 
-    core.run(runner).unwrap();
+    tokio::runtime::run2(runner.map(|_| ()).or_else(|e| {
+        println!("Error in publisher: {:?}", e);
+        Ok(())
+    }));
 }
 
 fn subscriber_thread() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let ctx = Rc::new(zmq::Context::new());
+    let ctx = Arc::new(zmq::Context::new());
 
-    let subscriber: Sub = Socket::builder(Rc::clone(&ctx), &handle)
+    let subscriber: Sub = Socket::builder(Arc::clone(&ctx))
         .connect("tcp://localhost:5561")
         .filter(b"")
         .try_into()
         .unwrap();
 
-    let syncclient: Req = Socket::builder(ctx, &handle)
+    let syncclient: Req = Socket::builder(ctx)
         .connect("tcp://localhost:5562")
         .try_into()
         .unwrap();
 
     let msg = zmq::Message::from_slice(b"").unwrap();
 
-    let recv = syncclient.recv();
-
     let runner = syncclient
         .send(msg.into())
-        .and_then(move |_| recv)
-        .and_then(|_| {
+        .and_then(|(sock, file)| Socket::from_sock_and_file(sock, file).recv())
+        .and_then(move |_| {
             subscriber
                 .stream()
                 .with_end(Stop)
@@ -132,7 +130,10 @@ fn subscriber_thread() {
                 })
         });
 
-    core.run(runner).unwrap();
+    tokio::runtime::run2(runner.map(|_| ()).or_else(|e| {
+        println!("Error in subscriber: {:?}", e);
+        Ok(())
+    }));
 }
 
 fn main() {

--- a/examples/zpub.rs
+++ b/examples/zpub.rs
@@ -20,17 +20,18 @@
 #![feature(try_from)]
 
 extern crate futures;
-extern crate tokio_core;
+extern crate tokio;
+extern crate tokio_timer;
 extern crate tokio_zmq;
 extern crate zmq;
 
-use std::io;
-use std::rc::Rc;
-use std::time::Duration;
 use std::convert::TryInto;
+use std::io;
+use std::sync::Arc;
+use std::time::Duration;
 
-use futures::Stream;
-use tokio_core::reactor::{Core, Interval};
+use futures::{FutureExt, StreamExt};
+use tokio_timer::{Timer, TimerError};
 use tokio_zmq::prelude::*;
 use tokio_zmq::{Error as ZmqFutError, Pub, Socket};
 
@@ -39,6 +40,7 @@ enum Error {
     ZmqFut(ZmqFutError),
     Zmq(zmq::Error),
     Io(io::Error),
+    Timer(TimerError),
 }
 
 impl From<ZmqFutError> for Error {
@@ -59,17 +61,21 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<TimerError> for Error {
+    fn from(e: TimerError) -> Self {
+        Error::Timer(e)
+    }
+}
+
 fn main() {
-    let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let ctx = Rc::new(zmq::Context::new());
-    let zpub: Pub = Socket::builder(ctx, &handle)
+    let ctx = Arc::new(zmq::Context::new());
+    let zpub: Pub = Socket::builder(ctx)
         .bind("tcp://*:5556")
         .try_into()
         .unwrap();
 
-    let producer = Interval::new(Duration::from_secs(1), &handle)
-        .unwrap()
+    let producer = Timer::default()
+        .interval(Duration::from_secs(1))
         .map_err(Error::from)
         .and_then(|_| {
             println!("Sending 'Hello'");
@@ -77,7 +83,10 @@ fn main() {
                 .map_err(Error::from)
                 .map(|msg| msg.into())
         })
-        .forward(zpub.sink::<Error>());
+        .forward(zpub.sink());
 
-    core.run(producer).unwrap();
+    tokio::runtime::run2(producer.map(|_| ()).or_else(|e| {
+        println!("Error in producer: {:?}", e);
+        Ok(())
+    }));
 }

--- a/examples/zpub.rs
+++ b/examples/zpub.rs
@@ -21,7 +21,7 @@
 
 extern crate futures;
 extern crate tokio;
-extern crate tokio_timer;
+extern crate tokio_timer_futures2 as tokio_timer;
 extern crate tokio_zmq;
 extern crate zmq;
 

--- a/src/async/future.rs
+++ b/src/async/future.rs
@@ -199,6 +199,10 @@ impl MultipartRequest {
                     .clear_write_ready2(cx)?;
                 cx.waker().wake();
             } else {
+                self.file
+                    .as_ref()
+                    .ok_or(Error::Reused)?
+                    .clear_write_ready2(cx)?;
                 return Ok(false);
             }
         }
@@ -377,6 +381,10 @@ impl MultipartResponse {
                     .clear_read_ready2(cx, Ready::readable())?;
                 cx.waker().wake();
             } else {
+                self.file
+                    .as_ref()
+                    .ok_or(Error::Reused)?
+                    .clear_read_ready2(cx, Ready::readable())?;
                 return Ok(false);
             }
         }

--- a/src/async/future.rs
+++ b/src/async/future.rs
@@ -44,14 +44,12 @@ use message::Multipart;
 /// #
 /// # extern crate zmq;
 /// # extern crate futures;
-/// # extern crate tokio_core;
 /// # extern crate tokio_zmq;
 /// #
-/// # use std::rc::Rc;
 /// # use std::convert::TryInto;
+/// # use std::sync::Arc;
 /// #
-/// # use futures::Future;
-/// # use tokio_core::reactor::Core;
+/// # use futures::{Future, FutureExt};
 /// # use tokio_zmq::prelude::*;
 /// # use tokio_zmq::async::MultipartRequest;
 /// # use tokio_zmq::{Error, Rep, Socket};
@@ -60,17 +58,15 @@ use message::Multipart;
 /// #     get_sock();
 /// # }
 /// # fn get_sock() -> impl Future<Item = (), Error = Error> {
-/// #     let core = Core::new().unwrap();
-/// #     let ctx = Rc::new(zmq::Context::new());
-/// #     let rep: Rep = Socket::builder(ctx, &core.handle())
+/// #     let ctx = Arc::new(zmq::Context::new());
+/// #     let rep: Rep = Socket::builder(ctx)
 /// #         .bind("tcp://*:5567")
 /// #         .try_into()
 /// #         .unwrap();
 /// #     let socket = rep.socket();
-/// #     let sock = socket.inner_sock();
-/// #     let file = socket.inner_file();
+/// #     let (sock, file) = socket.inner();
 /// #     let msg = zmq::Message::from_slice(format!("Hey").as_bytes()).unwrap();
-/// MultipartRequest::new(sock, file, msg.into()).and_then(|_| {
+/// MultipartRequest::new(sock, file, msg.into()).and_then(|(_, _)| {
 ///     // succesfull request
 ///     # Ok(())
 /// })
@@ -257,14 +253,12 @@ where
 /// #
 /// # extern crate zmq;
 /// # extern crate futures;
-/// # extern crate tokio_core;
 /// # extern crate tokio_zmq;
 /// #
-/// # use std::rc::Rc;
 /// # use std::convert::TryInto;
+/// # use std::sync::Arc;
 /// #
-/// # use futures::Future;
-/// # use tokio_core::reactor::Core;
+/// # use futures::{Future, FutureExt};
 /// # use tokio_zmq::prelude::*;
 /// # use tokio_zmq::async::{MultipartResponse};
 /// # use tokio_zmq::{Error, Multipart, Rep, Socket};
@@ -273,16 +267,14 @@ where
 /// #     get_sock();
 /// # }
 /// # fn get_sock() -> impl Future<Item = Multipart, Error = Error> {
-/// #     let core = Core::new().unwrap();
-/// #     let ctx = Rc::new(zmq::Context::new());
-/// #     let rep: Rep = Socket::builder(ctx, &core.handle())
+/// #     let ctx = Arc::new(zmq::Context::new());
+/// #     let rep: Rep = Socket::builder(ctx)
 /// #         .bind("tcp://*:5567")
 /// #         .try_into()
 /// #         .unwrap();
 /// #     let socket = rep.socket();
-/// #     let sock = socket.inner_sock();
-/// #     let file = socket.inner_file();
-/// MultipartResponse::new(sock, file).and_then(|multipart| {
+/// #     let (sock, file) = socket.inner();
+/// MultipartResponse::new(sock, file).and_then(|(multipart, (_, _))| {
 ///     // handle multipart response
 ///     # Ok(multipart)
 /// })

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -24,10 +24,12 @@
 
 pub mod future;
 pub mod sink;
+pub mod sink_stream;
 pub mod stream;
 
 pub use self::future::{MultipartRequest, MultipartResponse};
 pub use self::sink::MultipartSink;
+pub use self::sink_stream::MultipartSinkStream;
 pub use self::stream::{ControlledStream, EndingStream, MultipartStream, TimeoutStream};
 
 /// This type is used to determine what flags should be used when sending messages. If a message is

--- a/src/async/sink.rs
+++ b/src/async/sink.rs
@@ -18,7 +18,7 @@
  */
 
 //! This module defines the `MultipartSink` type. A wrapper around Sockets that implements
-//! `futures::Stream`.
+//! `futures::Sink`.
 
 use std::mem::swap;
 
@@ -44,14 +44,12 @@ use file::ZmqFile;
 ///
 /// extern crate zmq;
 /// extern crate futures;
-/// extern crate tokio_core;
+/// extern crate tokio;
 /// extern crate tokio_zmq;
 ///
-/// use std::rc::Rc;
+/// use std::sync::Arc;
 ///
-/// use futures::{Future, Sink};
-/// use tokio_core::reactor::Core;
-/// use tokio_zmq::async::{MultipartStream};
+/// use futures::{FutureExt, Sink, SinkExt};
 /// use tokio_zmq::{Error, Multipart, Socket};
 ///
 /// fn get_sink(socket: Socket) -> impl Sink<SinkItem = Multipart, SinkError = Error> {
@@ -59,17 +57,16 @@ use file::ZmqFile;
 /// }
 ///
 /// fn main() {
-///     let mut core = Core::new().unwrap();
-///     let context = Rc::new(zmq::Context::new());
-///     let socket = Socket::builder(context, &core.handle())
+///     let context = Arc::new(zmq::Context::new());
+///     let socket = Socket::builder(context)
 ///         .bind("tcp://*:5568")
 ///         .build(zmq::PUB)
 ///         .unwrap();
 ///     let sink = get_sink(socket);
 ///
-///     let msg = zmq::Message::from_slice(b"Some message").unwrap();
+///     let msg = zmq::Message::from_slice(b"Some message");
 ///
-///     core.run(sink.send(msg.into())).unwrap();
+///     // tokio::reactor::run2(sink.send(msg.into())).unwrap();
 /// }
 /// ```
 pub struct MultipartSink {

--- a/src/async/sink.rs
+++ b/src/async/sink.rs
@@ -141,8 +141,6 @@ impl MultipartSink {
     fn make_request(&mut self, multipart: Multipart) -> Result<(), Error> {
         match self.polling() {
             SinkState::Ready(sock, file) => {
-                file.clear_write_ready()?;
-
                 self.inner = SinkState::Pending(MultipartRequest::new(sock, file, multipart));
                 Ok(())
             }

--- a/src/async/sink.rs
+++ b/src/async/sink.rs
@@ -78,7 +78,7 @@ pub struct MultipartSink {
 
 pub(crate) enum SinkState {
     Ready(zmq::Socket, PollEvented2<File<ZmqFile>>),
-    Pending(MultipartRequest),
+    Pending(MultipartRequest<(zmq::Socket, PollEvented2<File<ZmqFile>>)>),
     Polling,
 }
 
@@ -121,7 +121,7 @@ impl MultipartSink {
 
     fn poll_request(
         &mut self,
-        mut request: MultipartRequest,
+        mut request: MultipartRequest<(zmq::Socket, PollEvented2<File<ZmqFile>>)>,
         cx: &mut Context,
     ) -> Result<Async<()>, Error> {
         match request.poll(cx)? {

--- a/src/async/sink_stream.rs
+++ b/src/async/sink_stream.rs
@@ -1,0 +1,215 @@
+use std::mem::swap;
+
+use futures::{Async, Sink, Stream};
+use futures::task::Context;
+use tokio_file_unix::File;
+use tokio::reactor::PollEvented2;
+use zmq;
+
+use async::sink::MultipartSink;
+use async::stream::MultipartStream;
+use error::Error;
+use file::ZmqFile;
+use message::Multipart;
+
+pub struct MultipartSinkStream {
+    inner: SinkStreamState,
+}
+
+enum SinkStreamState {
+    Sink(MultipartSink),
+    Stream(MultipartStream),
+    Both(
+        MultipartSink,
+        MultipartStream,
+        zmq::Socket,
+        PollEvented2<File<ZmqFile>>,
+    ),
+    Ready(zmq::Socket, PollEvented2<File<ZmqFile>>),
+    Polling,
+}
+
+impl MultipartSinkStream {
+    pub fn new(sock: zmq::Socket, file: PollEvented2<File<ZmqFile>>) -> Self {
+        MultipartSinkStream {
+            inner: SinkStreamState::Ready(sock, file),
+        }
+    }
+
+    fn polling(&mut self) -> SinkStreamState {
+        let mut state = SinkStreamState::Polling;
+
+        swap(&mut self.inner, &mut state);
+
+        state
+    }
+
+    fn poll_sink(
+        &mut self,
+        mut sink: MultipartSink,
+        stream: Option<MultipartStream>,
+        cx: &mut Context,
+    ) -> Result<Async<()>, Error> {
+        match sink.poll_flush(cx)? {
+            Async::Ready(_) => match sink.take_socket() {
+                Some((sock, file)) => {
+                    match stream {
+                        Some(mut stream) => {
+                            stream.give_socket(sock, file);
+                            self.inner = SinkStreamState::Stream(stream);
+                        }
+                        None => {
+                            self.inner = SinkStreamState::Ready(sock, file);
+                        }
+                    }
+                    Ok(Async::Ready(()))
+                }
+                None => Err(Error::Sink),
+            },
+            Async::Pending => {
+                match stream {
+                    Some(mut stream) => match sink.take_socket() {
+                        Some((sock, file)) => {
+                            self.inner = SinkStreamState::Both(sink, stream, sock, file);
+                        }
+                        None => {
+                            return Err(Error::Sink);
+                        }
+                    },
+                    None => {
+                        self.inner = SinkStreamState::Sink(sink);
+                    }
+                }
+
+                Ok(Async::Pending)
+            }
+        }
+    }
+
+    fn poll_stream(
+        &mut self,
+        mut stream: MultipartStream,
+        sink: Option<MultipartSink>,
+        cx: &mut Context,
+    ) -> Result<Async<Option<Multipart>>, Error> {
+        match stream.poll_next(cx)? {
+            Async::Ready(item) => match stream.take_socket() {
+                Some((sock, file)) => {
+                    match sink {
+                        Some(mut sink) => {
+                            sink.give_socket(sock, file);
+                            self.inner = SinkStreamState::Sink(sink);
+                        }
+                        None => {
+                            self.inner = SinkStreamState::Ready(sock, file);
+                        }
+                    }
+                    Ok(Async::Ready(item))
+                }
+                None => Err(Error::Stream),
+            },
+            Async::Pending => {
+                match sink {
+                    Some(mut sink) => match stream.take_socket() {
+                        Some((sock, file)) => {
+                            self.inner = SinkStreamState::Both(sink, stream, sock, file);
+                        }
+                        None => {
+                            return Err(Error::Stream);
+                        }
+                    },
+                    None => {
+                        self.inner = SinkStreamState::Stream(stream);
+                    }
+                }
+
+                Ok(Async::Pending)
+            }
+        }
+    }
+}
+
+impl Sink for MultipartSinkStream {
+    type SinkItem = Multipart;
+    type SinkError = Error;
+
+    fn start_send(&mut self, multipart: Self::SinkItem) -> Result<(), Self::SinkError> {
+        match self.polling() {
+            SinkStreamState::Ready(sock, file) => {
+                let mut sink = MultipartSink::new(sock, file);
+                sink.start_send(multipart)?;
+                self.inner = SinkStreamState::Sink(sink);
+                Ok(())
+            }
+            SinkStreamState::Stream(mut stream) => match stream.take_socket() {
+                Some((sock, file)) => {
+                    let mut sink = MultipartSink::new(sock, file);
+                    sink.start_send(multipart)?;
+                    match sink.take_socket() {
+                        Some((sock, file)) => {
+                            self.inner = SinkStreamState::Both(sink, stream, sock, file);
+                            Ok(())
+                        }
+                        None => Err(Error::Sink),
+                    }
+                }
+                None => Err(Error::Sink),
+            },
+            _ => Err(Error::Sink),
+        }
+    }
+
+    fn poll_ready(&mut self, cx: &mut Context) -> Result<Async<()>, Self::SinkError> {
+        self.poll_flush(cx)
+    }
+
+    fn poll_flush(&mut self, cx: &mut Context) -> Result<Async<()>, Self::SinkError> {
+        match self.polling() {
+            SinkStreamState::Ready(sock, file) => {
+                self.inner = SinkStreamState::Ready(sock, file);
+                Ok(Async::Ready(()))
+            }
+            SinkStreamState::Sink(sink) => self.poll_sink(sink, None, cx),
+            SinkStreamState::Stream(stream) => {
+                self.inner = SinkStreamState::Stream(stream);
+                Ok(Async::Pending)
+            }
+            SinkStreamState::Both(mut sink, stream, sock, file) => {
+                sink.give_socket(sock, file);
+                self.poll_sink(sink, Some(stream), cx)
+            }
+            SinkStreamState::Polling => Err(Error::Sink),
+        }
+    }
+
+    fn poll_close(&mut self, cx: &mut Context) -> Result<Async<()>, Self::SinkError> {
+        self.poll_flush(cx)
+    }
+}
+
+impl Stream for MultipartSinkStream {
+    type Item = Multipart;
+    type Error = Error;
+
+    fn poll_next(&mut self, cx: &mut Context) -> Result<Async<Option<Multipart>>, Self::Error> {
+        match self.polling() {
+            SinkStreamState::Ready(sock, file) => {
+                let stream = MultipartStream::new(sock, file);
+                self.poll_stream(stream, None, cx)
+            }
+            SinkStreamState::Sink(mut sink) => match sink.take_socket() {
+                Some((sock, file)) => {
+                    let stream = MultipartStream::new(sock, file);
+                    self.poll_stream(stream, Some(sink), cx)
+                }
+                None => Err(Error::Stream),
+            },
+            SinkStreamState::Both(sink, mut stream, sock, file) => {
+                stream.give_socket(sock, file);
+                self.poll_stream(stream, Some(sink), cx)
+            }
+            SinkStreamState::Stream(stream) => self.poll_stream(stream, None, cx),
+            SinkStreamState::Polling => Err(Error::Stream),
+        }
+    }
+}

--- a/src/async/sink_stream.rs
+++ b/src/async/sink_stream.rs
@@ -1,3 +1,25 @@
+/*
+ * This file is part of Tokio ZMQ.
+ *
+ * Copyright © 2017 Riley Trautman
+ *
+ * Tokio ZMQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tokio ZMQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tokio ZMQ.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//! This module defines the `MultipartSinkStream` type. A wrapper around Sockets that implements
+//! `futures::Sink` and `futures::Stream`.
+
 use std::mem::swap;
 
 use futures::{Async, Sink, Stream};
@@ -12,6 +34,45 @@ use error::Error;
 use file::ZmqFile;
 use message::Multipart;
 
+/// The `MultipartSinkStream` handles sending and receiving streams of data to and from ZeroMQ
+/// Sockets.
+///
+/// You shouldn't ever need to manually create one. Here's how to get one from a 'raw' `Socket`'
+/// type.
+///
+/// ### Example
+/// ```rust
+/// #![feature(conservative_impl_trait)]
+///
+/// extern crate zmq;
+/// extern crate futures;
+/// extern crate tokio;
+/// extern crate tokio_zmq;
+///
+/// use std::sync::Arc;
+///
+/// use futures::{FutureExt, Sink, Stream, StreamExt};
+/// use tokio_zmq::{Error, Multipart, Socket};
+///
+/// fn get_sink_stream(socket: Socket) -> impl Sink<SinkItem = Multipart, SinkError = Error> + Stream<Item = Multipart, Error = Error>
+/// {
+///     socket.sink_stream()
+/// }
+///
+/// fn main() {
+///     let context = Arc::new(zmq::Context::new());
+///     let socket = Socket::builder(context)
+///         .bind("tcp://*:5575")
+///         .build(zmq::REP)
+///         .unwrap();
+///
+///     let sink_stream = get_sink_stream(socket);
+///
+///     let (sink, stream) = sink_stream.split();
+///
+///     // tokio::reactor::run2(stream.forward(sink));
+/// }
+/// ```
 pub struct MultipartSinkStream {
     inner: SinkStreamState,
 }

--- a/src/async/stream.rs
+++ b/src/async/stream.rs
@@ -45,13 +45,11 @@ use prelude::{ControlHandler, EndHandler};
 ///
 /// extern crate zmq;
 /// extern crate futures;
-/// extern crate tokio_core;
 /// extern crate tokio_zmq;
 ///
-/// use std::rc::Rc;
+/// use std::sync::Arc;
 ///
-/// use futures::Stream;
-/// use tokio_core::reactor::Core;
+/// use futures::{Stream, StreamExt};
 /// use tokio_zmq::async::MultipartStream;
 /// use tokio_zmq::{Error, Multipart, Socket};
 ///
@@ -63,9 +61,8 @@ use prelude::{ControlHandler, EndHandler};
 /// }
 ///
 /// fn main() {
-///     let core = Core::new().unwrap();
-///     let context = Rc::new(zmq::Context::new());
-///     let socket = Socket::builder(context, &core.handle())
+///     let context = Arc::new(zmq::Context::new());
+///     let socket = Socket::builder(context)
 ///         .connect("tcp://localhost:5568")
 ///         .filter(b"")
 ///         .build(zmq::SUB)

--- a/src/async/stream.rs
+++ b/src/async/stream.rs
@@ -79,7 +79,7 @@ pub struct MultipartStream {
 
 pub(crate) enum StreamState {
     Ready(zmq::Socket, PollEvented2<File<ZmqFile>>),
-    Pending(MultipartResponse),
+    Pending(MultipartResponse<(zmq::Socket, PollEvented2<File<ZmqFile>>)>),
     Polling,
 }
 
@@ -122,11 +122,11 @@ impl MultipartStream {
 
     fn poll_response(
         &mut self,
-        mut response: MultipartResponse,
+        mut response: MultipartResponse<(zmq::Socket, PollEvented2<File<ZmqFile>>)>,
         cx: &mut Context,
     ) -> Result<Async<Option<Multipart>>, Error> {
         match response.poll(cx)? {
-            Async::Ready((item, sock, file)) => {
+            Async::Ready((item, (sock, file))) => {
                 self.inner = StreamState::Ready(sock, file);
 
                 Ok(Async::Ready(Some(item)))

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,6 +69,9 @@ impl fmt::Display for Error {
             Error::Zmq(ref e) => write!(f, "Error from ZeroMQ: {}", e),
             Error::Io(ref e) => write!(f, "Error creating file descriptor: {}", e),
             Error::Timer(ref e) => write!(f, "Error creating timer: {}", e),
+            Error::Sink => write!(f, "Could not send message to ZeroMQ"),
+            Error::Stream => write!(f, "Could not receive message from ZeroMQ"),
+            Error::Reused => write!(f, "Attempted to re-use already-used future"),
         }
     }
 }
@@ -79,6 +82,9 @@ impl StdError for Error {
             Error::Zmq(_) => "Error interacting with ZeroMQ",
             Error::Io(_) => "Error building socket",
             Error::Timer(_) => "Error creating timed stream",
+            Error::Sink => "Could not send message to ZeroMQ",
+            Error::Stream => "Could not receive message from ZeroMQ",
+            Error::Reused => "Attempted to re-use already-used future",
         }
     }
 
@@ -87,6 +93,7 @@ impl StdError for Error {
             Error::Zmq(ref e) => Some(e),
             Error::Io(ref e) => Some(e),
             Error::Timer(ref e) => Some(e),
+            _ => None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,12 @@ pub enum Error {
     Io(IoError),
     /// Stores Tokio Timer errors
     Timer(TimerError),
+    /// If Sink socket is not done handling current request
+    Sink,
+    /// If Stream socket is not done handling current request
+    Stream,
+    /// If a future is used after it is consumed
+    Reused,
 }
 
 impl From<ZmqError> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,8 @@
 extern crate futures;
 #[macro_use]
 extern crate log;
-extern crate tokio_core;
+extern crate mio;
+extern crate tokio;
 extern crate tokio_file_unix;
 extern crate tokio_timer;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ extern crate log;
 extern crate mio;
 extern crate tokio;
 extern crate tokio_file_unix;
-extern crate tokio_timer;
+extern crate tokio_timer_futures2 as tokio_timer;
 #[macro_use]
 extern crate tokio_zmq_derive;
 extern crate zmq;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,33 +44,27 @@
 //!
 //! extern crate zmq;
 //! extern crate futures;
-//! extern crate tokio_core;
+//! extern crate tokio;
 //! extern crate tokio_zmq;
 //!
 //! use std::convert::TryInto;
-//! use std::rc::Rc;
+//! use std::sync::Arc;
 //!
-//! use futures::Stream;
-//! use tokio_core::reactor::Core;
+//! use futures::{FutureExt, StreamExt};
 //! use tokio_zmq::prelude::*;
 //! use tokio_zmq::{Socket, Pub, Sub, Error};
 //!
 //! fn run() -> Result<(), Error> {
-//!     // Create a new Event Loop. Typically this will happen somewhere near the start of your
-//!     // application.
-//!     let mut core = Core::new()?;
-//!     let handle = core.handle();
-//!
 //!     // Create a new ZeroMQ Context. This context will be used to create all the sockets.
-//!     let context = Rc::new(zmq::Context::new());
+//!     let context = Arc::new(zmq::Context::new());
 //!
 //!     // Create our two sockets using the Socket builder pattern.
 //!     // Note that the variable is named zpub, since pub is a keyword
-//!     let zpub: Pub = Socket::builder(Rc::clone(&context), &handle)
+//!     let zpub: Pub = Socket::builder(Arc::clone(&context))
 //!         .bind("tcp://*:5561")
 //!         .try_into()?;
 //!
-//!     let sub: Sub = Socket::builder(context, &handle)
+//!     let sub: Sub = Socket::builder(context)
 //!         .bind("tcp://*:5562")
 //!         .filter(b"")
 //!         .try_into()?;
@@ -86,10 +80,12 @@
 //!             }
 //!             multipart
 //!         })
-//!         .forward(zpub.sink::<Error>());
+//!         .forward(zpub.sink());
 //!
 //!     // To avoid an infinte doctest, the actual core.run is commented out.
-//!     // core.run(runner)?;
+//!     // tokio::runtime::run2(runner.map(|_| ()).or_else(|e| {
+//!     //     println!("Error: {}", e);
+//!     // })?;
 //!     # let _ = runner;
 //!     # Ok(())
 //! }

--- a/src/socket/config.rs
+++ b/src/socket/config.rs
@@ -58,7 +58,7 @@ impl<'a> SocketBuilder<'a> {
     /// their socket builder (except PAIR sockets).
     pub fn new(ctx: Arc<zmq::Context>) -> Self {
         SocketBuilder {
-            ctx: ctx,
+            ctx,
             identity: None,
         }
     }
@@ -81,7 +81,7 @@ impl<'a> SocketBuilder<'a> {
 
         SockConfig {
             ctx: self.ctx,
-            bind: bind,
+            bind,
             connect: Vec::new(),
             identity: self.identity,
         }
@@ -98,7 +98,7 @@ impl<'a> SocketBuilder<'a> {
         SockConfig {
             ctx: self.ctx,
             bind: Vec::new(),
-            connect: connect,
+            connect,
             identity: self.identity,
         }
     }
@@ -109,8 +109,8 @@ impl<'a> SocketBuilder<'a> {
     pub fn pair(self, addr: &'a str, bind: bool) -> PairConfig<'a> {
         PairConfig {
             ctx: self.ctx,
-            addr: addr,
-            bind: bind,
+            addr,
+            bind,
             identity: self.identity,
         }
     }

--- a/src/socket/config.rs
+++ b/src/socket/config.rs
@@ -19,7 +19,7 @@
 
 //! This module contains `SocketBuilder` and related types.
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use zmq;
 use tokio::reactor::PollEvented2;
@@ -47,7 +47,7 @@ fn connect_all(sock: zmq::Socket, connects: &[&str]) -> zmq::Result<zmq::Socket>
 ///
 /// This struct contains a context and an identity.
 pub struct SocketBuilder<'a> {
-    ctx: Rc<zmq::Context>,
+    ctx: Arc<zmq::Context>,
     identity: Option<&'a [u8]>,
 }
 
@@ -56,7 +56,7 @@ impl<'a> SocketBuilder<'a> {
     ///
     /// All sockets that are created through the Tokio ZMQ library will use this as the base for
     /// their socket builder (except PAIR sockets).
-    pub fn new(ctx: Rc<zmq::Context>) -> Self {
+    pub fn new(ctx: Arc<zmq::Context>) -> Self {
         SocketBuilder {
             ctx: ctx,
             identity: None,
@@ -121,7 +121,7 @@ impl<'a> SocketBuilder<'a> {
 /// This contains all the information required to contstruct a valid socket, except in the case of
 /// SUB, which needs an additional `filter` parameter.
 pub struct SockConfig<'a> {
-    pub ctx: Rc<zmq::Context>,
+    pub ctx: Arc<zmq::Context>,
     pub bind: Vec<&'a str>,
     pub connect: Vec<&'a str>,
     pub identity: Option<&'a [u8]>,
@@ -193,7 +193,7 @@ impl<'a> SockConfig<'a> {
 ///
 /// This contains all the information required to contstruct a valid SUB socket
 pub struct SubConfig<'a> {
-    pub ctx: Rc<zmq::Context>,
+    pub ctx: Arc<zmq::Context>,
     pub bind: Vec<&'a str>,
     pub connect: Vec<&'a str>,
     pub filter: &'a [u8],
@@ -241,7 +241,7 @@ impl<'a> SubConfig<'a> {
 ///
 /// This contains all the information required to contstruct a valid PAIR socket
 pub struct PairConfig<'a> {
-    ctx: Rc<zmq::Context>,
+    ctx: Arc<zmq::Context>,
     addr: &'a str,
     bind: bool,
     identity: Option<&'a [u8]>,

--- a/src/socket/config.rs
+++ b/src/socket/config.rs
@@ -22,7 +22,7 @@
 use std::rc::Rc;
 
 use zmq;
-use tokio_core::reactor::{Handle, PollEvented};
+use tokio::reactor::PollEvented2;
 use tokio_file_unix::File;
 
 use socket::Socket;
@@ -45,10 +45,9 @@ fn connect_all(sock: zmq::Socket, connects: &[&str]) -> zmq::Result<zmq::Socket>
 
 /// The root struct for a Socket builder
 ///
-/// This struct contains a context and a handle to the current event loop.
+/// This struct contains a context and an identity.
 pub struct SocketBuilder<'a> {
     ctx: Rc<zmq::Context>,
-    handle: &'a Handle,
     identity: Option<&'a [u8]>,
 }
 
@@ -57,10 +56,9 @@ impl<'a> SocketBuilder<'a> {
     ///
     /// All sockets that are created through the Tokio ZMQ library will use this as the base for
     /// their socket builder (except PAIR sockets).
-    pub fn new(ctx: Rc<zmq::Context>, handle: &'a Handle) -> Self {
+    pub fn new(ctx: Rc<zmq::Context>) -> Self {
         SocketBuilder {
             ctx: ctx,
-            handle: handle,
             identity: None,
         }
     }
@@ -69,7 +67,6 @@ impl<'a> SocketBuilder<'a> {
     pub fn identity(self, identity: &'a [u8]) -> Self {
         SocketBuilder {
             ctx: self.ctx,
-            handle: self.handle,
             identity: Some(identity),
         }
     }
@@ -84,7 +81,6 @@ impl<'a> SocketBuilder<'a> {
 
         SockConfig {
             ctx: self.ctx,
-            handle: self.handle,
             bind: bind,
             connect: Vec::new(),
             identity: self.identity,
@@ -101,7 +97,6 @@ impl<'a> SocketBuilder<'a> {
 
         SockConfig {
             ctx: self.ctx,
-            handle: self.handle,
             bind: Vec::new(),
             connect: connect,
             identity: self.identity,
@@ -114,7 +109,6 @@ impl<'a> SocketBuilder<'a> {
     pub fn pair(self, addr: &'a str, bind: bool) -> PairConfig<'a> {
         PairConfig {
             ctx: self.ctx,
-            handle: self.handle,
             addr: addr,
             bind: bind,
             identity: self.identity,
@@ -128,7 +122,6 @@ impl<'a> SocketBuilder<'a> {
 /// SUB, which needs an additional `filter` parameter.
 pub struct SockConfig<'a> {
     pub ctx: Rc<zmq::Context>,
-    pub handle: &'a Handle,
     pub bind: Vec<&'a str>,
     pub connect: Vec<&'a str>,
     pub identity: Option<&'a [u8]>,
@@ -164,7 +157,6 @@ impl<'a> SockConfig<'a> {
     pub fn build(self, kind: zmq::SocketType) -> Result<Socket, Error> {
         let SockConfig {
             ctx,
-            handle,
             bind,
             connect,
             identity,
@@ -179,12 +171,7 @@ impl<'a> SockConfig<'a> {
 
         let fd = sock.get_fd()?;
 
-        let sock = Rc::new(sock);
-
-        let file = Rc::new(PollEvented::new(
-            File::new_nb(ZmqFile::from_raw_fd(fd))?,
-            handle,
-        )?);
+        let file = PollEvented2::new(File::new_nb(ZmqFile::from_raw_fd(fd))?);
 
         Ok(Socket::from_sock_and_file(sock, file))
     }
@@ -194,7 +181,6 @@ impl<'a> SockConfig<'a> {
     pub fn filter(self, pattern: &'a [u8]) -> SubConfig<'a> {
         SubConfig {
             ctx: self.ctx,
-            handle: self.handle,
             bind: self.bind,
             connect: self.connect,
             identity: self.identity,
@@ -208,7 +194,6 @@ impl<'a> SockConfig<'a> {
 /// This contains all the information required to contstruct a valid SUB socket
 pub struct SubConfig<'a> {
     pub ctx: Rc<zmq::Context>,
-    pub handle: &'a Handle,
     pub bind: Vec<&'a str>,
     pub connect: Vec<&'a str>,
     pub filter: &'a [u8],
@@ -230,7 +215,6 @@ impl<'a> SubConfig<'a> {
     pub fn build(self, _: zmq::SocketType) -> Result<Socket, Error> {
         let SubConfig {
             ctx,
-            handle,
             bind,
             connect,
             filter,
@@ -247,12 +231,7 @@ impl<'a> SubConfig<'a> {
 
         let fd = sock.get_fd()?;
 
-        let sock = Rc::new(sock);
-
-        let file = Rc::new(PollEvented::new(
-            File::new_nb(ZmqFile::from_raw_fd(fd))?,
-            handle,
-        )?);
+        let file = PollEvented2::new(File::new_nb(ZmqFile::from_raw_fd(fd))?);
 
         Ok(Socket::from_sock_and_file(sock, file))
     }
@@ -263,7 +242,6 @@ impl<'a> SubConfig<'a> {
 /// This contains all the information required to contstruct a valid PAIR socket
 pub struct PairConfig<'a> {
     ctx: Rc<zmq::Context>,
-    handle: &'a Handle,
     addr: &'a str,
     bind: bool,
     identity: Option<&'a [u8]>,
@@ -279,7 +257,6 @@ impl<'a> PairConfig<'a> {
     pub fn build(self, _: zmq::SocketType) -> Result<Socket, Error> {
         let PairConfig {
             ctx,
-            handle,
             addr,
             bind,
             identity,
@@ -297,12 +274,7 @@ impl<'a> PairConfig<'a> {
 
         let fd = sock.get_fd()?;
 
-        let sock = Rc::new(sock);
-
-        let file = Rc::new(PollEvented::new(
-            File::new_nb(ZmqFile::from_raw_fd(fd))?,
-            handle,
-        )?);
+        let file = PollEvented2::new(File::new_nb(ZmqFile::from_raw_fd(fd))?);
 
         Ok(Socket::from_sock_and_file(sock, file))
     }

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -79,12 +79,24 @@ impl Socket {
     }
 
     /// Retrieve a Future that consumes a multipart, sending it to the socket
-    pub fn send(self, multipart: Multipart) -> MultipartRequest {
+    pub fn send<T>(self, multipart: Multipart) -> MultipartRequest<T>
+    where
+        T: From<(zmq::Socket, PollEvented2<File<ZmqFile>>)>,
+    {
         MultipartRequest::new(self.sock, self.file, multipart)
     }
 
     /// Retrieve a Future that produces a multipart, getting it fromthe socket
-    pub fn recv(self) -> MultipartResponse {
+    pub fn recv<T>(self) -> MultipartResponse<T>
+    where
+        T: From<(zmq::Socket, PollEvented2<File<ZmqFile>>)>,
+    {
         MultipartResponse::new(self.sock, self.file)
+    }
+}
+
+impl From<(zmq::Socket, PollEvented2<File<ZmqFile>>)> for Socket {
+    fn from((sock, file): (zmq::Socket, PollEvented2<File<ZmqFile>>)) -> Self {
+        Socket { sock, file }
     }
 }

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -22,7 +22,7 @@
 pub mod config;
 pub mod types;
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use zmq;
 use tokio::reactor::PollEvented2;
@@ -45,7 +45,7 @@ pub struct Socket {
 
 impl Socket {
     /// Start a new Socket Config builder
-    pub fn builder(ctx: Rc<zmq::Context>) -> SocketBuilder<'static> {
+    pub fn builder(ctx: Arc<zmq::Context>) -> SocketBuilder<'static> {
         SocketBuilder::new(ctx)
     }
 

--- a/src/socket/types.rs
+++ b/src/socket/types.rs
@@ -21,11 +21,14 @@
 
 use std::convert::TryFrom;
 
+use tokio::reactor::PollEvented2;
+use tokio_file_unix::File;
 use zmq;
 
+use error::Error;
+use file::ZmqFile;
 use socket::config::{PairConfig, SockConfig, SubConfig};
 use socket::Socket;
-use error::Error;
 
 /* -------------------------------------------------------------------------- */
 

--- a/src/socket/types.rs
+++ b/src/socket/types.rs
@@ -32,7 +32,7 @@ use error::Error;
 /// The DEALER `SocketType` wrapper type.
 ///
 /// Dealer implements `StreamSocket` and `SinkSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[sink]
 pub struct Dealer {
@@ -44,7 +44,7 @@ pub struct Dealer {
 /// The PAIR `SocketType` wrapper type.
 ///
 /// Pair implements `StreamSocket` and `SinkSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[sink]
 #[try_from = "PairConfig"]
@@ -57,7 +57,7 @@ pub struct Pair {
 /// The PUB `SocketType` wrapper type
 ///
 /// Pub implements `SinkSocket`.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[sink]
 pub struct Pub {
     inner: Socket,
@@ -68,7 +68,7 @@ pub struct Pub {
 /// The PULL `SocketType` wrapper type
 ///
 /// Pull implements `StreamSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 pub struct Pull {
     inner: Socket,
@@ -79,7 +79,7 @@ pub struct Pull {
 /// The PUSH `SocketType` wrapper type
 ///
 /// Push implements `SinkSocket`.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[sink]
 pub struct Push {
     inner: Socket,
@@ -90,7 +90,7 @@ pub struct Push {
 /// The REP `SocketType` wrapper type
 ///
 /// Rep implements `StreamSocket` and `SinkSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[sink]
 pub struct Rep {
@@ -102,7 +102,7 @@ pub struct Rep {
 /// The REQ `SocketType` wrapper type
 ///
 /// Req implements `StreamSocket` and `SinkSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[sink]
 pub struct Req {
@@ -114,7 +114,7 @@ pub struct Req {
 /// The ROUTER `SocketType` wrapper type
 ///
 /// Router implements `StreamSocket` and `SinkSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[sink]
 pub struct Router {
@@ -126,7 +126,7 @@ pub struct Router {
 /// The SUB `SocketType` wrapper type
 ///
 /// Sub implements `StreamSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[try_from = "SubConfig"]
 pub struct Sub {
@@ -138,7 +138,7 @@ pub struct Sub {
 /// The XPUB `SocketType` wrapper type
 ///
 /// Xpub implements `StreamSocket` and `SinkSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[sink]
 pub struct Xpub {
@@ -150,7 +150,7 @@ pub struct Xpub {
 /// The XSUB `SocketType` wrapper type
 ///
 /// Xsub implements `StreamSocket` and `SinkSocket`, and has an associated controlled variant.
-#[derive(Clone, SocketWrapper)]
+#[derive(SocketWrapper)]
 #[stream]
 #[sink]
 pub struct Xsub {

--- a/tokio-zmq-derive/Cargo.toml
+++ b/tokio-zmq-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-zmq-derive"
 description = "Provides derivation for Tokio ZMQ Socket wrapper types"
-version = "0.1.2"
+version = "0.4.0"
 license = "GPL-3.0"
 authors = ["Riley Trautman <asonix.dev@gmail.com>"]
 repository = "https://github.com/asonix/tokio-zmq"

--- a/tokio-zmq-derive/src/lib.rs
+++ b/tokio-zmq-derive/src/lib.rs
@@ -25,11 +25,7 @@ fn socket_derive(s: synstructure::Structure) -> quote::Tokens {
         let as_socket = s.bound_impl(
             "::prelude::AsSocket",
             quote! {
-                fn socket(&self) -> &Socket {
-                    &self.inner
-                }
-
-                fn into_socket(self) -> Socket {
+                fn socket(self) -> Socket {
                     self.inner
                 }
             },

--- a/tokio-zmq-derive/src/lib.rs
+++ b/tokio-zmq-derive/src/lib.rs
@@ -22,6 +22,17 @@ fn socket_derive(s: synstructure::Structure) -> quote::Tokens {
     });
 
     if let Some(sb) = socket_binding {
+        let name = sb.ast().ident;
+        let from_parts = s.bound_impl(
+            "From<(zmq::Socket, PollEvented2<File<ZmqFile>>)>",
+            quote! {
+                fn from(tup: (zmq::Socket, PollEvented2<File<ZmqFile>>)) -> Self {
+                    #name {
+                        inner: tup.into(),
+                    }
+                }
+            },
+        );
         let as_socket = s.bound_impl(
             "::prelude::AsSocket",
             quote! {
@@ -31,7 +42,6 @@ fn socket_derive(s: synstructure::Structure) -> quote::Tokens {
             },
         );
 
-        let name = sb.ast().ident;
         let try_from = build_try_from(&s, name);
 
         let stream = if has_attr(&s, "stream") {
@@ -47,6 +57,7 @@ fn socket_derive(s: synstructure::Structure) -> quote::Tokens {
         };
 
         quote! {
+            #from_parts
             #as_socket
             #stream
             #sink


### PR DESCRIPTION
This branch updates to tokio 0.1 and futures 0.2

In order to accomplish this, the Socket, futures, sink, and streams have been rewritten to avoid using `Rc<>`. This allows futures containing a socket to be `Send`.

This also introduces the `.sink_stream()` function for creating a `Sink + Stream` item from a socket, since both `.sink()` and `.stream()` consume the socket, now.

Unfortunately, if `.split()`, provided by the futures library, is used on a `MultipartSinkStream`, the individual parts are both `Send`, but they can't be sent separately. There's no compiler enforcement of this, and it leads to panics if attempted.

I'd like to clean up `.send()` and `.sink()` before merging, since the `MultipartRequest` future currently yields a `(zmq::Socket, PollEvented2<File<ZmqFile>>)`, when it would be much more convenient if it handed back the same socket that was used to create it. `MultipartResponse` currently yields a `(Multipart, zmq::Socket, PollEvented2<File<ZmqFile>>)`.

Additionally, I'd like to document the changes that I've made before merging.

This also depends on a local fork of tokio-timer, which has been updated to use futures-0.2.0-alpha. This library needs to be published, possibly as tokio-timer-futures2 before tokio-0.1-futures-0.2 can be pubished and merged.